### PR TITLE
Add Composer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /sass/sass-cache
 .idea
 /tests/.sass-cache
+vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "richthegeek/phpsass",
+    "description": "PHPSass is a PHP compiler for SASS, a popular CSS pre-processor language.",
+    "license": "BSD-2-Clause",
+    "homepage": "http://phpsass.com",
+    "support": {
+        "issues": "https://github.com/richthegeek/phpsass/issues",
+        "source": "https://github.com/richthegeek/phpsass"
+    },
+    "authors": [
+        {
+            "name": "Richard Lyon",
+            "homepage": "https://github.com/richthegeek"
+        },
+        {
+            "name": "Sebastian Siemssen",
+            "homepage": "https://twitter.com/thefubhy"
+        },
+        {
+            "name": "Steve Jones",
+            "homepage": "https://github.com/darthsteven"
+        },
+        {
+            "name": "Sam Richard",
+            "homepage": "https://github.com/snugug"
+        }
+    ],
+    "autoload": {
+        "classmap": [
+            "script/",
+            "renderers/",
+            "tree/",
+            "SassException.php",
+            "SassFile.php",
+            "SassParser.php"
+        ]
+    }
+}


### PR DESCRIPTION
[Composer](http://getcomposer.org/) is a package manager which will allow projects to state a dependency on PHPSass and have it automatically download it upon installation. Composer will also generate a class-loader to ease loading PHPSass classes. This PR adds `composer.json` to the project for the Composer support.

With composer.json around, you can do things like:

Download PHPSass easily:

```
composer create-project richthegeek/phpsass
```

Add "richthegeek/phpsass" to your own composer.json's "require" file to have the project download PHPSass on installation.

```
composer install
```

Use the Composer class loader to lazy-load the PHPSass classes only when needed:

```
require_once('vendor/autoload.php');
```

You can find out more about the composer.json schema at http://getcomposer.org/doc/04-schema.md . Thanks!
