### PR TITLE
Allow file containing .css not to be parsed as css

### DIFF
--- a/tree/SassImportNode.php
+++ b/tree/SassImportNode.php
@@ -18,7 +18,7 @@
 class SassImportNode extends SassNode {
   const IDENTIFIER = '@';
   const MATCH = '/^@import\s+(.+)/i';
-  const MATCH_CSS = '/^((url)\((.+)\)|.+" \w+|http|.+\.css)/im';
+  const MATCH_CSS = '/^((url)\((.+)\)|.+" \w+|http|.+\.css$)/im';
   const FILES = 1;
 
   /**


### PR DESCRIPTION
(in example, with a Rails-like asset pipeline and x.css.php)
