### PR TITLE
Implemented default values referring to other arguments

### DIFF
--- a/script/SassScriptFunction.php
+++ b/script/SassScriptFunction.php
@@ -254,6 +254,7 @@ class SassScriptFunction {
     }
 
     // print_r(array($required, $provided, $_required));
+    $provided_copy = $provided;
 
     foreach ($required as $name=>$default) {
       if (count($provided)) {
@@ -261,6 +262,16 @@ class SassScriptFunction {
       }
       elseif ($default !== NULL) {
         $arg = $default;
+
+        // for mixins with default values that refer to other arguments
+        // (e.g. border-radius($topright: 0, $bottomright: $topright, $bottomleft: $topright, $topleft: $topright)
+        if (is_string($default) && $default[0]=='$') {
+          $referred = trim(trim($default, '$'));
+          $pos = array_search($referred, array_keys($required));
+          if ($pos!==false && array_key_exists($pos, $provided_copy)) {
+            $arg = $provided_copy[$pos];
+          }
+        }
       }
       else {
         throw new SassMixinNodeException("Function::$name: Required variable ($name) not given.\nFunction defined: " . $source->token->filename . '::' . $source->token->line . "\nFunction used", $source);


### PR DESCRIPTION
Given this mixin:

```
@mixin radius($topleft, $topright: $topleft, $bottomright: $topleft, $bottomleft: $topleft) {

    -moz-border-radius-topleft:     $topleft;
    -moz-border-radius-topright:    $topright;
    -moz-border-radius-bottomright: $bottomright;
    -moz-border-radius-bottomleft:  $bottomleft;
    -webkit-border-radius:          $topleft $topright $bottomright $bottomleft;
    border-radius:                  $topleft $topright $bottomright $bottomleft;

}

a { @include radius(4px); }
```

expected output is

```
a {
  -moz-border-radius-topleft: 4px;
  -moz-border-radius-topright: 4px;
  -moz-border-radius-bottomright: 4px;
  -moz-border-radius-bottomleft: 4px;
  -webkit-border-radius: 4px 4px 4px 4px;
  border-radius: 4px 4px 4px 4px;
}
```

However, PHPSass generates

```
a {
  -moz-border-radius-topleft: 4px;
  -moz-border-radius-topright: false;
  -moz-border-radius-bottomright: false;
  -moz-border-radius-bottomleft: false;
  -webkit-border-radius: 4px false false false;
  border-radius: 4px false false false;
}
```

I've added some code to change that - pull if you like :-)
