### PR TITLE
Init a list to empty

### DIFF
--- a/script/SassScriptFunctions.php
+++ b/script/SassScriptFunctions.php
@@ -896,9 +896,13 @@ class SassScriptFunctions {
 
   public static function append($list, $val, $sep = ', ') {
     if ($list instanceOf SassString) {
-      $list = new SassList($list->toString());
+        $list = new SassList($list->toString());
+        $list->append($val, $sep);
+    } elseif ($list instanceOf SassBoolean && $list->value === false) {
+        $list = new SassList( $val, $sep );
+    } else {
+        $list->append($val, $sep);
     }
-    $list->append($val, $sep);
     return $list;
   }
 


### PR DESCRIPTION
In [bourbon](http://thoughtbot.com/bourbon/) and specificaly in [html5-input-types](https://github.com/thoughtbot/bourbon/blob/master/app/assets/stylesheets/addons/_html5-input-types.scss) there is an empty list which is then populated in an @each loop.

Phpsass crashes on the first append call in this loop :
    Call to undefined method SassBoolean::append() in .../phpsass/script/SassScriptFunctions.php on line 901

I managed to get this working making an ugly special case to the append method, but this does not seem a good option to me. The problem seems to be from the lexer, if I understand. But I don't know how to solve this bug in a good way ...
