### PR TITLE
@media inside mixins, loops, etc should not fatal error or recurse infinitely

### DIFF
--- a/tests/media_in_for.css
+++ b/tests/media_in_for.css
@@ -1,0 +1,6 @@
+@media only screen and (min-width: 500px) {
+  #gallery {
+  width: 520px; } }
+@media only screen and (min-width: 1000px) {
+  #gallery {
+  width: 1020px; } }

--- a/tests/media_in_for.scss
+++ b/tests/media_in_for.scss
@@ -1,0 +1,10 @@
+$fiver: 500px;
+#gallery {
+    @for $i from 1 through 2 {
+        $screenWidth: $fiver * $i;
+        $galleryWidth: ($fiver * $i) + 20px;
+        @media only screen and (min-width: $screenWidth) {
+            width: $galleryWidth;
+        }
+    }
+}

--- a/tests/media_in_mixin.css
+++ b/tests/media_in_mixin.css
@@ -1,0 +1,3 @@
+@media (min-width: 768px) {
+    body {
+    width: 50px; } }

--- a/tests/media_in_mixin.scss
+++ b/tests/media_in_mixin.scss
@@ -1,0 +1,9 @@
+@mixin mediaContent() {
+    @media (min-width: 768px) {
+        @content;
+    }
+}
+
+@include mediaContent() {
+    body { width: 50px; }
+}

--- a/tests/mixin-content.css
+++ b/tests/mixin-content.css
@@ -1,4 +1,5 @@
 #logo {
 	background-image: url("/images/logo.png"); }
 * html #logo {
+	width: 500px;
 	background-image: url("/images/logo.gif"); }

--- a/tests/mixin-content.sass
+++ b/tests/mixin-content.sass
@@ -1,3 +1,4 @@
+$fiver: 500px
 =ie6
 	* html &
 		@content
@@ -5,4 +6,5 @@
 #logo
 	background-image: url("/images/logo.png")
 	+ie6
+		width: $fiver
 		background-image: url("/images/logo.gif")

--- a/tests/mixin-content.scss
+++ b/tests/mixin-content.scss
@@ -1,3 +1,4 @@
+$fiver: 500px;
 @mixin ie6 {
 	* html & {
 		@content
@@ -7,6 +8,7 @@
 #logo {
 	background-image: url("/images/logo.png");
 	@include ie6 {
+		width: $fiver;
 		background-image: url("/images/logo.gif");
 	}
 }

--- a/tests/phpSassTest.php
+++ b/tests/phpSassTest.php
@@ -305,6 +305,14 @@ class PHPSass_TestCase extends PHPUnit_Framework_TestCase {
     $this->runSassTest('list_variable.scss');
   }
 
+  public function testMediaInFor() {
+    $this->runSassTest('media_in_for.scss');
+  }
+
+  public function testMediaInMixin() {
+    $this->runSassTest('media_in_mixin.scss');
+  }
+
   public function testWarnImported() {
     $this->markTestIncomplete('This test has not been implemented yet.');
     //$this->runSassTest('warn_imported.sass');

--- a/tree/SassContentNode.php
+++ b/tree/SassContentNode.php
@@ -48,7 +48,12 @@ class SassContentNode extends SassNode {
   public function parse($pcontext) {
     $return = $this;
     $context = new SassContext($pcontext);
-    return ($context->getContent());
+    $children = array();
+    foreach ($context->getContent() as $child) {
+      $child->parent = $this->parent;
+      $children = array_merge($children, $child->parse($pcontext));
+    }
+    return $children;
   }
 
   /**


### PR DESCRIPTION
Fixes for issues:
#55 "Using @media in a @mixin causes SassContext to Wrap itself"
#92 "using @media/@include with @content in a @mixin causes infinite loop error"
#86 "scss syntax passed through mixin @content is not being parsed"

(Note: Only fixes the first test case in #92.  See comments below)

Also fixed an issue in the same code where media nodes in loops were only parsing their tokens once so variables inside the @media rule would only get evaluated on the first pass through the loop.

Includes test cases.
