### PR TITLE
Backward compatibility SASS with SCSS

### DIFF
--- a/tree/SassPropertyNode.php
+++ b/tree/SassPropertyNode.php
@@ -17,8 +17,8 @@
  */
 class SassPropertyNode extends SassNode
 {
-  const MATCH_PROPERTY_SCSS = '/^([^\s=:"(\\\\:)]*)\s*(?:(= )|:)([^\:].*?)?(\s*!important.*)?$/';
-  const MATCH_PROPERTY_NEW = '/^([^\s=:"]+)\s*(?:(= )|:)([^\:].*?)?(\s*!important.*)?$/';
+  const MATCH_PROPERTY_SCSS = '/^([^\s=:"(\\\\:)]*)\s*(?:(= )|:)([^\:].*?)?(\s*!important[^;]*)?;*$/';
+  const MATCH_PROPERTY_NEW = '/^([^\s=:"]+)\s*(?:(= )|:)([^\:].*?)?(\s*!important[^;]*)?;*$/';
   const MATCH_PROPERTY_OLD = '/^:([^\s=:]+)(?:\s*(=)\s*|\s+|$)(.*)(\s*!important.*)?/';
   const MATCH_PSUEDO_SELECTOR = '/^:*\w[-\w]+\(?/i';
   const MATCH_INTERPOLATION = '/^#\{(.*?)\}/i';


### PR DESCRIPTION
SASS now work fine with ";" at the end line.

another.sass
body {
    font-size: 10em;
}

Parse old =>
body {
    font-size: 10;;
}

Parse now =>
body {
    font-size: 10em;
}
