### PR TITLE
Add basic support for 'vw', 'vh', 'vmin', 'vmax' units.

### DIFF
--- a/script/literals/SassNumber.php
+++ b/script/literals/SassNumber.php
@@ -55,6 +55,7 @@ class SassNumber extends SassLiteral
     'px' => 96
   );
   private static $validUnits = array(
+    'vw', 'vh', 'vmin', 'vmax',
     'in', 'cm', 'mm', 'pc', 'pt', 'em', 'rem', 'ex', 'px', '%', 's', 'deg'
   );
 


### PR DESCRIPTION
Add basic support for `vw`, `vh`, `vmin`, `vmax` units (CSS3 Viewport-percentage lengths).

Without this patch phpsass removes, for example, `vh` from `height: 20vh;`, resulting in an invalid `height: 20;` line.
Now it works, and `height: 10 + 10vh;` also results in correct `height: 20vh;`.

Actually, original SASS has no 'invalid' units, all units there are supported, even non-existent ones.

See:
http://www.w3.org/TR/css3-values/#viewport-relative-lengths
http://caniuse.com/viewport-units
