### PR TITLE
Fix RegExp compilation error with php 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
 env:
   - PHPUNIT_ARGS=--group=sass
 before_script:

--- a/tree/SassFunctionDefinitionNode.php
+++ b/tree/SassFunctionDefinitionNode.php
@@ -18,7 +18,7 @@
 class SassFunctionDefinitionNode extends SassNode
 {
   const NODE_IDENTIFIER = FALSE;
-  const MATCH = '/^@function\s+([_-\w]+)\s*(?:\((.*?)\))?\s*$/im';
+  const MATCH = '/^@function\s+([_\-\w]+)\s*(?:\((.*?)\))?\s*$/im';
   const IDENTIFIER = 1;
   const NAME = 1;
   const ARGUMENTS = 2;


### PR DESCRIPTION
preg_match(): Compilation failed: invalid range in character class at offset 18

also enable php 5.5 on travis, for me all tests pass with this
