### PR TITLE
Recursion loop prevented

### DIFF
--- a/script/SassScriptLexer.php
+++ b/script/SassScriptLexer.php
@@ -84,7 +84,13 @@ class SassScriptLexer
         $tokens[] = new SassNumber($match);
       } elseif (($match = SassString::isa($string)) !== false) {
         $stringed = new SassString($match);
-        if (strlen($stringed->quote) == 0 && SassList::isa($string) !== false) {
+        if (
+          strlen($stringed->quote) == 0 && 
+          SassList::isa($string) !== false &&
+          // recursion loop prevented for expressions 
+          // like "transition: -webkit-transform 1s"
+          !preg_match("/^\-\w+\-\w$", $stringed->value)
+          ) {
           $tokens[] = new SassList($string);
         } else {
           $tokens[] = $stringed;


### PR DESCRIPTION
Current parser enters a recursion loop when mis-evaluating vendor-specific transition values "-vendor-transform 1s" as a list which previously would create a new SassList which calls the lexer as part of the analysis.
