### PR TITLE
Throw exception when count of closing brackets don't match opening brackets

### DIFF
--- a/tests/phpSassTest.php
+++ b/tests/phpSassTest.php
@@ -406,4 +406,13 @@ class PHPSass_TestCase extends PHPUnit_Framework_TestCase
   {
     $this->runSassTest('mixin_setvar.scss');
   }
+
+  public function testTokenLevelException() {
+      try {
+        $this->runSassTest('token_level.scss', false, array('debug' => true));
+      } catch (SassException $e) {
+          $message = 'Too many closing brackets';
+          $this->assertEquals($message, substr($e->getMessage(), 0, strlen($message)));
+      }
+  }
 }

--- a/tests/token_level.css
+++ b/tests/token_level.css
@@ -1,0 +1,6 @@
+foo {
+	margin: 10px;
+	bar {
+	   margin: 10px;
+	}}
+}

--- a/tests/token_level.scss
+++ b/tests/token_level.scss
@@ -1,0 +1,2 @@
+foo { margin: 10px; }
+foo bar { margin: 10px; }}


### PR DESCRIPTION
Removing static from $level changes the semantic of the variable but I don't think it is really meant to be static. However, this implementation gives the possibility to check whether all brackets which were opened in one file are closed again.
