### PR TITLE
fix for fatal error when using @extend as an immediate child of a mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 composer.lock
 /.project
 /.settings
+/nbproject/

--- a/tests/mixin_extend.css
+++ b/tests/mixin_extend.css
@@ -1,0 +1,3 @@
+#a,
+#b {
+  color: red; }

--- a/tests/mixin_extend.scss
+++ b/tests/mixin_extend.scss
@@ -1,0 +1,13 @@
+%bar {
+	color: red;
+}
+@mixin foo {
+	@extend %bar;
+}
+
+#a { 
+	@include foo;
+}
+#b { 
+	@include foo;
+}

--- a/tree/SassMixinNode.php
+++ b/tree/SassMixinNode.php
@@ -90,4 +90,15 @@ class SassMixinNode extends SassNode
   {
     return $token->source[0] === self::NODE_IDENTIFIER;
   }
+  
+  /**
+   * Resolves selectors.
+   * Interpolates SassScript in selectors and resolves any parent references or
+   * appends the parent selectors.
+   * @param SassContext $context the context in which this node is parsed
+   * @return array
+   */
+  public function resolveSelectors($context){
+    return $this->parent->resolveSelectors($context);
+  }
 }


### PR DESCRIPTION
fix for fatal error "Call to undefined method SassMixinNode::resolveSelectors() in tree/SassExtendNode.php on line 49" when using @extend as an immediate child of a mixin (see test case).
