### PR TITLE
@extends in rules of 2 o more levels deep were always ignored

### DIFF
--- a/tree/SassNode.php
+++ b/tree/SassNode.php
@@ -142,14 +142,21 @@ class SassNode
     } else {
       $this->children[] = $child;
       $child->parent = $this;
-      $child->root = $this->root;
-    }
-    // The child will have children if a debug node has been added
-    foreach ($child->children as $grandchild) {
-      $grandchild->root = $this->root;
+      $child->setRoot($this->root);
     }
   }
-
+  
+  /**
+   * Sets a root recursively.
+   * @param SassNode the new root node
+   */
+  public function setRoot($root){
+    $this->root = $root;
+    foreach ($this->children as $child) {
+      $child->setRoot($this->root);
+    }
+  }
+  
   /**
    * Returns a value indicating if this node has children
    * @return boolean true if the node has children, false if not


### PR DESCRIPTION
In the following example the @extend rule was completely ignored

File a:

``` SCSS
@import 'b';
```

File b:

``` SCSS
.foo {
    color: red;
}
.bar {
    .baz {
        @extend .foo;
    }
}
```

Expected output: 

``` CSS
.foo, .bar .baz {
  color: red;
}
```

Actual output:

``` CSS
.foo {
  color: red;
}
```

The problem was that when "moving" nodes of "b" to tree "a", the root property was updated only on the first 2 levels. This fix adds a method SassNode::setRoot which changes the root of every node of the subtree being "moved".
