### PR TITLE
Compact renderer should not output placeholders

### DIFF
--- a/renderers/SassCompactRenderer.php
+++ b/renderers/SassCompactRenderer.php
@@ -136,8 +136,15 @@ class SassCompactRenderer extends SassCompressedRenderer
    * @param SassNode $node the node being rendered
    * @return string the rendered selectors
    */
-  protected function renderSelectors($node)
-  {
-    return join(', ', $node->selectors);
-  }
+    protected function renderSelectors($node)
+    {
+      $selectors = array();
+      foreach ($node->selectors as $selector) {
+        if (!$node->isPlaceholder($selector)) {
+          $selectors[] = $selector;
+        }
+      }
+
+      return join(', ', $selectors);
+    }
 }


### PR DESCRIPTION
``` scss
%foo {
  color: blue;
}
#bar {
  @extend %foo;
}
```

should output

``` css
#bar {
  color: blue;
}
```

instead of

``` css
%foo, #bar {
  color: blue;
}
```
