### PR TITLE
Removed rbga conversion to transparent on zero alpha

### DIFF
--- a/script/literals/SassColour.php
+++ b/script/literals/SassColour.php
@@ -804,9 +804,7 @@ class SassColour extends SassLiteral
       }
     }
 
-    if ($rgba[3] == 0) {
-      return 'transparent';
-    } elseif ($rgba[3] < 1) {
+    if ($rgba[3] < 1) {
       $rgba[3] = str_replace(',','.',round($rgba[3], 2));
 
       return sprintf('rgba(%d, %d, %d, %s)', $rgba[0], $rgba[1], $rgba[2], $rgba[3]);


### PR DESCRIPTION
Removed rgba conversion to transparent, when alpha is zero as it was incompatible with Firefox, which defaults to black color, while Webkit browsers defaulted to a neighboring color.

fixes #82