### PR TITLE
FireSass has been replaced by FireCompass Update SassCompactRenderer.php

### DIFF
--- a/renderers/SassCompactRenderer.php
+++ b/renderers/SassCompactRenderer.php
@@ -108,7 +108,7 @@ class SassCompactRenderer extends SassCompressedRenderer
    * Renders debug information.
    * If the node has the debug_info options set true the line number and filename
    * are rendered in a format compatible with
-   * {@link https://addons.mozilla.org/en-US/firefox/addon/103988/ FireSass}.
+   * {@link https://addons.mozilla.org/en-US/firefox/addon/firecompass-for-firebug/ FireCompass}.
    * Else if the node has the line_numbers option set true the line number and
    * filename are rendered in a comment.
    * @param SassNode $node the node being rendered
@@ -118,14 +118,8 @@ class SassCompactRenderer extends SassCompressedRenderer
   {
     $indent = $this->getIndent($node);
     $debug = '';
-
-    if ($node->getDebug_info()) {
-      $debug .= $indent . self::DEBUG_INFO_RULE . '{';
-      $debug .= 'filename{' . self::DEBUG_INFO_PROPERTY . ':' . preg_replace('/([^-\w])/', '\\\\\1', "file://{$node->filename}") . ';}';
-      $debug .= 'line{' . self::DEBUG_INFO_PROPERTY . ":'{$node->line}';}";
-      $debug .= "}\n";
-    } elseif ($node->getLine_numbers()) {
-      $debug .= "$indent/* line {$node->line} {$node->filename} */\n";
+    if ($node->getDebug_info() || $node->getLine_numbers()) {
+      $debug .= "$indent/* line {$node->line}, {$node->filename} */\n";
     }
 
     return $debug;


### PR DESCRIPTION
We need to patch this so that projects using this library as a dependency can make use of FireCompass because FireSass was replaced by FireCompass.  A project that uses this as a dependency is sassy on drupal.org.  Here is the related issue: https://www.drupal.org/node/2312869