### PR TITLE
Small PHP7 compatibility fix

### DIFF
--- a/script/SassScriptLexer.php
+++ b/script/SassScriptLexer.php
@@ -67,7 +67,7 @@ class SassScriptLexer
     }
 	$tokens = array();
     // whilst the string is not empty, split it into it's tokens.
-    while ($string !== false) {
+    while (strlen($string)) {
       if (($match = $this->isWhitespace($string)) !== false) {
         $tokens[] = null;
       } elseif (($match = SassScriptFunction::isa($string)) !== false) {


### PR DESCRIPTION
In PHP5 `substr($a, strlen($a))` will return `false`.

In PHP7 it will return empty string, causing endless loop in condition
```php
while ($string !== false) { /*...*/ }
```

So i made a quick fix