### PR TITLE
tree/SassMixinNode.php: Removed unused 'count' on a string

### DIFF
--- a/tree/SassMixinNode.php
+++ b/tree/SassMixinNode.php
@@ -63,7 +63,6 @@ class SassMixinNode extends SassNode
     $mixin = $pcontext->getMixin($this->name);
     $context = new SassContext($pcontext);
     $context->content = $this->children;
-    $argc = count($this->args);
     $count = 0;
 
     $args = SassScriptFunction::extractArgs($this->args, false, $context);


### PR DESCRIPTION
The output is assigned to an unused variable and 'count'
on strings is not allowed anymore in PHP 7.3.